### PR TITLE
Implement a number of traits for `Hex`

### DIFF
--- a/src/hex.rs
+++ b/src/hex.rs
@@ -28,7 +28,7 @@ use std::fmt::{Debug, Display, Formatter};
 ///
 /// ```
 /// use sodg::Hex;
-/// let d = Hex::from_i64(65534);
+/// let d = Hex::from(65534);
 /// assert_eq!("00-00-00-00-00-00-FF-FE", d.print());
 /// ```
 ///
@@ -36,7 +36,7 @@ use std::fmt::{Debug, Display, Formatter};
 ///
 /// ```
 /// use sodg::Hex;
-/// let d = Hex::from_i64(65534);
+/// let d = Hex::from(65534);
 /// assert_eq!(65534, d.to_i64().unwrap());
 /// ```
 #[derive(Serialize, Deserialize, Clone)]
@@ -80,7 +80,7 @@ impl Hex {
     ///
     /// ```
     /// use sodg::Hex;
-    /// let d = Hex::from_i64(2);
+    /// let d = Hex::from(2);
     /// assert_eq!(8, d.len())
     /// ```
     pub fn bytes(&self) -> &[u8] {
@@ -154,40 +154,6 @@ impl Hex {
     pub fn parse(hex: String) -> Self {
         let s = hex.replace('-', "");
         Self::from_vec(hex::decode(s).unwrap())
-    }
-
-    /// Make `Hex` from `i64`.
-    ///
-    /// ```
-    /// use sodg::Hex;
-    /// let d = Hex::from_i64(65536);
-    /// assert_eq!("00-00-00-00-00-01-00-00", d.print());
-    /// ```
-    pub fn from_i64(d: i64) -> Self {
-        Self::from_slice(&d.to_be_bytes())
-    }
-
-    /// From `bool`.
-    ///
-    /// ```
-    /// use sodg::Hex;
-    /// let d = Hex::from_bool(true);
-    /// assert_eq!("01", d.print());
-    /// ```
-    pub fn from_bool(d: bool) -> Self {
-        Self::from_slice(&(if d { [1] } else { [0] }))
-    }
-
-    /// Make `Hex` from `f64`.
-    ///
-    /// ```
-    /// use std::f64::consts::PI;
-    /// use sodg::Hex;
-    /// let d = Hex::from_f64(PI);
-    /// assert_eq!("40-09-21-FB-54-44-2D-18", d.print());
-    /// ```
-    pub fn from_f64(d: f64) -> Self {
-        Self::from_slice(&d.to_be_bytes())
     }
 
     /// Make `Hex` from `String`.
@@ -327,10 +293,50 @@ impl Hex {
     }
 }
 
+impl From<i64> for Hex {
+    /// Make `Hex` from `i64`.
+    ///
+    /// ```
+    /// use sodg::Hex;
+    /// let d = Hex::from(65536);
+    /// assert_eq!("00-00-00-00-00-01-00-00", d.print());
+    /// ```
+    fn from(d: i64) -> Self {
+        Self::from_slice(&d.to_be_bytes())
+    }
+}
+
+impl From<f64> for Hex {
+    /// Make `Hex` from `f64`.
+    ///
+    /// ```
+    /// use std::f64::consts::PI;
+    /// use sodg::Hex;
+    /// let d = Hex::from(PI);
+    /// assert_eq!("40-09-21-FB-54-44-2D-18", d.print());
+    /// ```
+    fn from(d: f64) -> Self {
+        Self::from_slice(&d.to_be_bytes())
+    }
+}
+
+impl From<bool> for Hex {
+    /// From `bool`.
+    ///
+    /// ```
+    /// use sodg::Hex;
+    /// let d = Hex::from(true);
+    /// assert_eq!("01", d.print());
+    /// ```
+    fn from(d: bool) -> Self {
+        Self::from_slice(&(if d { [1] } else { [0] }))
+    }
+}
+
 #[test]
 fn simple_int() -> Result<()> {
     let i = 42;
-    let d = Hex::from_i64(i);
+    let d = Hex::from(i);
     assert_eq!(i, d.to_i64()?);
     assert_eq!("00-00-00-00-00-00-00-2A", d.print());
     Ok(())
@@ -339,7 +345,7 @@ fn simple_int() -> Result<()> {
 #[test]
 fn simple_bool() -> Result<()> {
     let b = true;
-    let d = Hex::from_bool(b);
+    let d = Hex::from(b);
     assert_eq!(b, d.to_bool()?);
     assert_eq!("01", d.print());
     Ok(())
@@ -348,7 +354,7 @@ fn simple_bool() -> Result<()> {
 #[test]
 fn simple_float() -> Result<()> {
     let f = std::f64::consts::PI;
-    let d = Hex::from_f64(f);
+    let d = Hex::from(f);
     assert_eq!(f, d.to_f64()?);
     assert_eq!("40-09-21-FB-54-44-2D-18", d.print());
     Ok(())
@@ -357,8 +363,8 @@ fn simple_float() -> Result<()> {
 #[test]
 fn compares_with_data() -> Result<()> {
     let i = 42;
-    let left = Hex::from_i64(i);
-    let right = Hex::from_i64(i);
+    let left = Hex::from(i);
+    let right = Hex::from(i);
     assert_eq!(left, right);
     Ok(())
 }

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -54,9 +54,11 @@ impl Debug for Hex {
 
 impl PartialEq for Hex {
     fn eq(&self, other: &Self) -> bool {
-        self.print() == other.print()
+        self.bytes() == other.bytes()
     }
 }
+
+impl Eq for Hex {}
 
 impl Display for Hex {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -478,5 +480,16 @@ fn takes_one_byte() -> Result<()> {
 fn measures_length() -> Result<()> {
     let d = Hex::from_str_bytes("Ура!");
     assert_eq!(7, d.len());
+    Ok(())
+}
+
+#[test]
+fn correct_equality() -> Result<()> {
+    let d = Hex::from_str("DE-AD-BE-EF")?;
+    let d1 = Hex::from_str("AA-BB")?;
+    let d2 = Hex::from_str("DE-AD-BE-EF")?;
+    assert_eq!(d, d);
+    assert_ne!(d, d1);
+    assert_eq!(d, d2);
     Ok(())
 }

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -78,7 +78,7 @@ use crate::Hex;
 fn inspects_simple_object() -> Result<()> {
     let mut g = Sodg::empty();
     g.add(0)?;
-    g.put(0, Hex::from_str("hello"))?;
+    g.put(0, Hex::from_str_bytes("hello"))?;
     g.add(1)?;
     g.bind(0, 1, "foo")?;
     let txt = g.inspect("")?;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -90,7 +90,7 @@ impl Sodg {
     /// use sodg::Sodg;
     /// let mut g = Sodg::empty();
     /// g.add(42).unwrap();
-    /// g.put(42, Hex::from_str("hello, world!")).unwrap();
+    /// g.put(42, Hex::from_str_bytes("hello, world!")).unwrap();
     /// ```
     ///
     /// If vertex `v1` is absent, an `Err` will be returned.
@@ -112,7 +112,7 @@ impl Sodg {
     /// use sodg::Sodg;
     /// let mut g = Sodg::empty();
     /// g.add(42).unwrap();
-    /// let data = Hex::from_str("hello, world!");
+    /// let data = Hex::from_str_bytes("hello, world!");
     /// g.put(42, data.clone()).unwrap();
     /// assert_eq!(data, g.data(42).unwrap());
     /// ```
@@ -477,7 +477,7 @@ fn binds_to_root() -> Result<()> {
 #[test]
 fn sets_simple_data() -> Result<()> {
     let mut g = Sodg::empty();
-    let data = Hex::from_str("hello");
+    let data = Hex::from_str_bytes("hello");
     g.add(0)?;
     g.put(0, data.clone())?;
     assert_eq!(data, g.data(0)?);

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -71,10 +71,10 @@ use crate::Hex;
 fn saves_and_loads() -> Result<()> {
     let mut g = Sodg::empty();
     g.add(0)?;
-    g.put(0, Hex::from_str("hello"))?;
+    g.put(0, Hex::from_str_bytes("hello"))?;
     g.add(1)?;
     g.bind(0, 1, "foo")?;
-    g.put(1, Hex::from_str("foo"))?;
+    g.put(1, Hex::from_str_bytes("foo"))?;
     let tmp = TempDir::new()?;
     let file = tmp.path().join("foo.sodg");
     g.save(file.as_path())?;

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -31,7 +31,7 @@ impl Sodg {
     /// use sodg::Sodg;
     /// let mut g = Sodg::empty();
     /// g.add(0).unwrap();
-    /// g.put(0, Hex::from_str("hello")).unwrap();
+    /// g.put(0, Hex::from_str_bytes("hello")).unwrap();
     /// g.add(1).unwrap();
     /// g.bind(0, 1, "foo").unwrap();
     /// g.bind(0, 1, "bar").unwrap();
@@ -97,7 +97,7 @@ use crate::Hex;
 fn prints_simple_graph() -> Result<()> {
     let mut g = Sodg::empty();
     g.add(0)?;
-    g.put(0, Hex::from_str("hello"))?;
+    g.put(0, Hex::from_str_bytes("hello"))?;
     g.add(1)?;
     g.bind(0, 1, "foo")?;
     let xml = g.to_xml()?;


### PR DESCRIPTION
This is a conservative re-implementation of certain `Hex` methods to fit Rust's standard library traits more easily (#29). The changes can be summarized as:

- Implemented conversion to `Hex` using Rust's standard `From` trait.
- Moved `parse` functionality into the `FromStr` trait. Removed an `unwrap` from the implementation, allowing for proper parsing error handling.
- Renamed `from_str` and `from_string` to `from_str_bytes` and `from_string_bytes`, to make way for the `FromStr::from_str` method and to make their meaning more clear.
- Did a more proper implementation of the `PartialEq::eq` method, removing the need for allocations.
- Implemented the marker trait `Eq`, signifying the true equivalence relation, as `Hex` matches all criteria. This won't have any visible effect on our current code, but might make interfacing with some methods of the standard library easier.

I'll write up the failed experiments and proposals of what to improve next in the issue.