### PR TITLE
#20: implement proof-of-concept BFS "garbage collection" algorithm

### DIFF
--- a/src/ctors.rs
+++ b/src/ctors.rs
@@ -145,8 +145,7 @@ fn prohibits_orphan_edges() -> Result<()> {
     let mut g = Sodg::empty();
     g.alerts_off();
     g.add(0)?;
-    g.bind(0, 1, "foo")?;
-    assert!(g.alerts_on().is_err());
+    assert!(g.bind(0, 1, "foo").is_err());
     Ok(())
 }
 
@@ -158,6 +157,7 @@ fn prohibits_labels_of_broken_format(#[case] a: &str) {
     let mut g = Sodg::empty();
     g.alerts_off();
     g.add(0).unwrap();
+    g.add(1).unwrap();
     g.bind(0, 1, a).unwrap();
     assert!(g.alerts_on().is_err());
 }

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -1,0 +1,76 @@
+use crate::Sodg;
+use anyhow::{Context, Result};
+use std::collections::VecDeque;
+
+impl Sodg {
+    pub fn collect(&mut self, v: u32) -> Result<()> {
+        let mut queue = VecDeque::new();
+        queue.push_back(v);
+        while !queue.is_empty() {
+            let collected_vertex_id = queue
+                .pop_front()
+                .context("A non-empty queue failed to yield an element, this shouldn't happen.")?;
+            let collected_vertex = self
+                .vertices
+                .get(&collected_vertex_id)
+                .context(format!("Failed to get v{collected_vertex_id}"))?
+                .clone();
+            if !collected_vertex.parents.is_empty() {
+                continue;
+            } else {
+                for edge in &collected_vertex.edges {
+                    queue.push_back(edge.to);
+                    self.vertices
+                        .get_mut(&edge.to)
+                        .context(format!("Failed to get v{}", edge.to))?
+                        .parents
+                        .remove(&collected_vertex_id);
+                }
+                self.vertices.remove(&collected_vertex_id);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[test]
+fn does_not_collect_owned() -> Result<()> {
+    let mut g = Sodg::empty();
+    g.add(1)?;
+    g.add(2)?;
+    g.bind(1, 2, "x")?;
+    g.collect(2)?;
+    assert!(g.vertices.get(&2).is_some());
+    Ok(())
+}
+
+#[test]
+fn collects_simple_graph() -> Result<()> {
+    let mut g = Sodg::empty();
+    g.add(1)?;
+    g.add(2)?;
+    g.add(3)?;
+    g.add(4)?;
+    g.bind(1, 2, "x")?;
+    g.bind(1, 3, "y")?;
+    g.bind(2, 4, "z")?;
+    g.collect(1)?;
+    assert!(g.is_empty());
+    Ok(())
+}
+
+#[test]
+fn collects_complicated_graph() -> Result<()> {
+    let mut g = Sodg::empty();
+    for i in 1..=5 {
+        g.add(i)?;
+    }
+    g.bind(1, 2, "x")?;
+    g.bind(1, 3, "y")?;
+    g.bind(2, 4, "z")?;
+    g.bind(3, 5, "a")?;
+    g.bind(4, 3, "b")?;
+    g.collect(1)?;
+    assert!(g.is_empty());
+    Ok(())
+}

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -3,9 +3,9 @@ use anyhow::{Context, Result};
 use std::collections::VecDeque;
 
 impl Sodg {
-    /// Attempts to collect the vertex `v`.
+    /// Attempts to collect the vertex.
     ///
-    /// If there are no edges leading to `v`, then it is deleted and all its children are collected.
+    /// If there are no edges leading to it, then it is deleted and all its children are collected.
     /// Otherwise, nothing happens.
     ///
     /// ```
@@ -21,28 +21,28 @@ impl Sodg {
     /// g.data(1).unwrap(); // Successfully collect 1
     /// assert!(g.data(1).is_err());
     /// ```
-    pub(crate) fn collect(&mut self, v: u32) -> Result<()> {
+    pub(crate) fn collect(&mut self, start: u32) -> Result<()> {
         let mut queue = VecDeque::new();
-        queue.push_back(v);
+        queue.push_back(start);
         while !queue.is_empty() {
-            let collected_vertex_id = queue
+            let v = queue
                 .pop_front()
                 .context("A non-empty queue failed to yield an element, this shouldn't happen.")?;
-            let collected_vertex = self
+            let vtx = self
                 .vertices
-                .get(&collected_vertex_id)
-                .context(format!("Failed to get v{collected_vertex_id}"))?
+                .get(&v)
+                .context(format!("Failed to get v{v}"))?
                 .clone();
-            if collected_vertex.parents.is_empty() {
-                for edge in &collected_vertex.edges {
+            if vtx.parents.is_empty() {
+                for edge in &vtx.edges {
                     queue.push_back(edge.to);
                     self.vertices
                         .get_mut(&edge.to)
                         .context(format!("Failed to get v{}", edge.to))?
                         .parents
-                        .remove(&collected_vertex_id);
+                        .remove(&v);
                 }
-                self.vertices.remove(&collected_vertex_id);
+                self.vertices.remove(&v);
             }
         }
         Ok(())

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -3,6 +3,24 @@ use anyhow::{Context, Result};
 use std::collections::VecDeque;
 
 impl Sodg {
+    /// Attempts to collect the vertex `v`.
+    ///
+    /// If there are no edges leading to `v`, then it is deleted and all its children are collected.
+    /// Otherwise, nothing happens.
+    ///
+    /// ```
+    /// use sodg::{Hex, Sodg};
+    /// let mut g = Sodg::empty();
+    /// g.add(1).unwrap();
+    /// g.put(1, Hex::from(0)).unwrap();
+    /// g.add(2).unwrap();
+    /// g.put(2, Hex::from(0)).unwrap();
+    /// g.bind(1, 2, "x").unwrap();
+    /// g.data(2).unwrap(); // Try to collect 2
+    /// assert!(g.data(2).is_ok());
+    /// g.data(1).unwrap(); // Successfully collect 1
+    /// assert!(g.data(1).is_err());
+    /// ```
     pub(crate) fn collect(&mut self, v: u32) -> Result<()> {
         let mut queue = VecDeque::new();
         queue.push_back(v);
@@ -15,9 +33,7 @@ impl Sodg {
                 .get(&collected_vertex_id)
                 .context(format!("Failed to get v{collected_vertex_id}"))?
                 .clone();
-            if !collected_vertex.parents.is_empty() {
-                continue;
-            } else {
+            if collected_vertex.parents.is_empty() {
                 for edge in &collected_vertex.edges {
                     queue.push_back(edge.to);
                     self.vertices

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -3,7 +3,7 @@ use anyhow::{Context, Result};
 use std::collections::VecDeque;
 
 impl Sodg {
-    pub fn collect(&mut self, v: u32) -> Result<()> {
+    pub(crate) fn collect(&mut self, v: u32) -> Result<()> {
         let mut queue = VecDeque::new();
         queue.push_back(v);
         while !queue.is_empty() {

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -33,7 +33,7 @@ impl Sodg {
                 .get(&v)
                 .context(format!("Failed to get v{v}"))?
                 .clone();
-            if vtx.parents.is_empty() {
+            if vtx.parents.is_empty() && vtx.taken {
                 for edge in &vtx.edges {
                     queue.push_back(edge.to);
                     self.vertices
@@ -70,7 +70,10 @@ fn collects_simple_graph() -> Result<()> {
     g.bind(1, 2, "x")?;
     g.bind(1, 3, "y")?;
     g.bind(2, 4, "z")?;
-    g.collect(1)?;
+    g.data(4)?;
+    g.data(2)?;
+    g.data(1)?;
+    g.data(3)?;
     assert!(g.is_empty());
     Ok(())
 }
@@ -86,7 +89,10 @@ fn collects_complicated_graph() -> Result<()> {
     g.bind(2, 4, "z")?;
     g.bind(3, 5, "a")?;
     g.bind(4, 3, "b")?;
-    g.collect(1)?;
+    for i in 1..=5 {
+        g.data(i)?;
+    }
+    // g.collect(1)?;
     assert!(g.is_empty());
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ mod alerts;
 mod ctors;
 mod debug;
 mod edge;
+mod gc;
 mod hex;
 mod inspect;
 mod merge;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -127,9 +127,10 @@ impl Sodg {
     pub fn data(&mut self, v: u32) -> Result<Hex> {
         let vtx = self
             .vertices
-            .get(&v)
+            .get_mut(&v)
             .context(format!("Can't find ν{}", v))?;
         let data = vtx.data.clone();
+        vtx.taken = true;
         self.collect(v)?;
         Ok(data)
     }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -110,27 +110,6 @@ impl Sodg {
         Ok(())
     }
 
-    /// Read vertex data without submitting the vertex to garbage collection.
-    ///
-    /// ```
-    /// use sodg::Hex;
-    /// use sodg::Sodg;
-    /// let mut g = Sodg::empty();
-    /// g.add(42).unwrap();
-    /// let data = Hex::from_str_bytes("hello, world!");
-    /// g.put(42, data.clone()).unwrap();
-    /// assert_eq!(data, g.peek_data(42).unwrap());
-    /// ```
-    ///
-    /// If vertex `v1` is absent, an `Err` will be returned.
-    pub fn peek_data(&self, v: u32) -> Result<Hex> {
-        let vtx = self
-            .vertices
-            .get(&v)
-            .context(format!("Can't find ν{}", v))?;
-        Ok(vtx.data.clone())
-    }
-
     /// Read vertex data, and then submit the vertex to garbage collection.
     ///
     /// ```
@@ -509,7 +488,7 @@ fn sets_simple_data() -> Result<()> {
     let data = Hex::from_str_bytes("hello");
     g.add(0)?;
     g.put(0, data.clone())?;
-    assert_eq!(data, g.peek_data(0)?);
+    assert_eq!(data, g.data(0)?);
     Ok(())
 }
 
@@ -564,7 +543,7 @@ fn builds_list_of_kids() -> Result<()> {
 fn gets_data_from_empty_vertex() -> Result<()> {
     let mut g = Sodg::empty();
     g.add(0)?;
-    assert!(g.peek_data(0)?.is_empty());
+    assert!(g.data(0)?.is_empty());
     Ok(())
 }
 

--- a/src/script.rs
+++ b/src/script.rs
@@ -208,7 +208,7 @@ fn simple_command() -> Result<()> {
     );
     let total = s.deploy_to(&mut g)?;
     assert_eq!(4, total);
-    assert_eq!("привет", g.peek_data(1)?.to_utf8()?);
+    assert_eq!("привет", g.data(1)?.to_utf8()?);
     assert_eq!(1, g.kid(0, "foo").unwrap());
     Ok(())
 }

--- a/src/script.rs
+++ b/src/script.rs
@@ -208,7 +208,7 @@ fn simple_command() -> Result<()> {
     );
     let total = s.deploy_to(&mut g)?;
     assert_eq!(4, total);
-    assert_eq!("привет", g.data(1)?.to_utf8()?);
+    assert_eq!("привет", g.peek_data(1)?.to_utf8()?);
     assert_eq!(1, g.kid(0, "foo").unwrap());
     Ok(())
 }

--- a/src/vertex.rs
+++ b/src/vertex.rs
@@ -27,6 +27,7 @@ pub(crate) struct Vertex {
     pub edges: Vec<Edge>,
     pub data: Hex,
     pub parents: HashSet<u32>,
+    pub taken: bool,
 }
 
 impl Vertex {
@@ -42,6 +43,7 @@ impl Vertex {
             edges: vec![],
             data: Hex::empty(),
             parents: HashSet::new(),
+            taken: false,
         }
     }
 }

--- a/src/vertex.rs
+++ b/src/vertex.rs
@@ -19,12 +19,14 @@
 // SOFTWARE.
 
 use crate::{Deserialize, Edge, Hex, Serialize};
+use std::collections::HashSet;
 
 /// A vertex in the graph.
 #[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct Vertex {
     pub edges: Vec<Edge>,
     pub data: Hex,
+    pub parents: HashSet<u32>,
 }
 
 impl Vertex {
@@ -39,6 +41,7 @@ impl Vertex {
         Vertex {
             edges: vec![],
             data: Hex::empty(),
+            parents: HashSet::new(),
         }
     }
 }


### PR DESCRIPTION
This is a minimal implementation of a very simple BFS "garbage collection" algorithm. It doesn't support cyclic references, common mark-and-sweep use-cases, and runs on every `Sodg::data` call, as outlined in (#20). 