### PR TITLE
62

### DIFF
--- a/src/ops.rs
+++ b/src/ops.rs
@@ -156,7 +156,7 @@ impl Sodg {
             .context(format!("Can't find ν{v}"))?;
         if !vtx.full {
             return Err(anyhow!(format!(
-                "#data: call #data before ν{v} isn't full impossible"
+                "#data: Calling #data before ν{v} is empty is not possible"
             )));
         }
         let data = vtx.data.clone();
@@ -509,6 +509,6 @@ fn check_for_data_receiving_before_put() -> Result<()> {
     let mut g = Sodg::empty();
     g.add(1)?;
     let actual = format!("{}", g.data(1).unwrap_err().root_cause());
-    assert_eq!(true, actual.contains("#data: call #data before"));
+    assert_eq!(true, actual.contains("#data: Calling #data before"));
     Ok(())
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -106,13 +106,14 @@ impl Sodg {
             .vertices
             .get_mut(&v)
             .context(format!("Can't find ν{v}"))?;
-        if vtx.posted {
-            return Err(anyhow!(
-                "The vertex isn't available, #put() was called earlier"
-            ));
+        if vtx.full {
+            return Err(anyhow!(format!(
+                "The ν{} is full, #put() was called earlier",
+                v
+            )));
         }
         vtx.data = d.clone();
-        vtx.posted = true;
+        vtx.full = true;
         self.validate(vec![v])?;
         trace!("#data: data of ν{v} set to {d}");
         Ok(())
@@ -489,10 +490,7 @@ fn checks_for_put_called_once() -> Result<()> {
     g.add(1)?;
     g.bind(0, 1, "bar/baz")?;
     g.put(0, Hex::from(42))?;
-    let actual = g.put(0, Hex::from(42)).unwrap_err();
-    assert_eq!(
-        format!("{}", actual.root_cause()),
-        "The vertex isn't available, #put() was called earlier"
-    );
+    let actual = format!("{}", g.put(0, Hex::from(42)).unwrap_err().root_cause());
+    assert_eq!(true, actual.contains("#put() was called earlier"));
     Ok(())
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -108,7 +108,7 @@ impl Sodg {
             .context(format!("Can't find ν{v}"))?;
         if vtx.full {
             return Err(anyhow!(format!(
-                "The ν{} is full, #put() was called earlier",
+                "#put: The ν{} is full, #put was called earlier",
                 v
             )));
         }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -417,7 +417,7 @@ fn gets_data_from_empty_vertex() -> Result<()> {
     let mut g = Sodg::empty();
     g.add(0)?;
     g.put(0, Hex::empty())?;
-    assert!(!g.full(0)?);
+    assert!(g.full(0)?);
     Ok(())
 }
 
@@ -517,9 +517,7 @@ fn check_for_data_receiving_before_put() -> Result<()> {
 fn checks_for_empty_hex_not_full() -> Result<()> {
     let mut g = Sodg::empty();
     g.add(1)?;
-    g.add(2)?;
-    g.bind(1, 2, "Hi, i'm the dog my name is Ruby!")?;
-    g.put(2, Hex::empty())?;
-    assert!(!g.full(2).unwrap());
+    g.put(1, Hex::empty())?;
+    assert!(g.full(1).unwrap());
     Ok(())
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -416,8 +416,8 @@ fn builds_list_of_kids() -> Result<()> {
 fn gets_data_from_empty_vertex() -> Result<()> {
     let mut g = Sodg::empty();
     g.add(0)?;
-    g.put(0, Hex::from(42))?;
-    assert!(!g.data(0)?.is_empty());
+    g.put(0, Hex::empty())?;
+    assert!(!g.full(0)?);
     Ok(())
 }
 
@@ -514,7 +514,7 @@ fn check_for_data_receiving_before_put() -> Result<()> {
 }
 
 #[test]
-fn checks_for_put_make_vert_full() -> Result<()> {
+fn checks_for_empty_hex_not_full() -> Result<()> {
     let mut g = Sodg::empty();
     g.add(1)?;
     g.add(2)?;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -514,7 +514,7 @@ fn check_for_data_receiving_before_put() -> Result<()> {
 }
 
 #[test]
-fn checks_for_empty_hex_not_full() -> Result<()> {
+fn checks_for_empty_hex_full() -> Result<()> {
     let mut g = Sodg::empty();
     g.add(1)?;
     g.put(1, Hex::empty())?;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -488,7 +488,7 @@ fn checks_for_put_called_once() -> Result<()> {
     g.add(0)?;
     g.add(1)?;
     g.bind(0, 1, "bar/baz")?;
-    g.put(0, Hex::from(42)).unwrap();
+    g.put(0, Hex::from(42))?;
     let actual = g.put(0, Hex::from(42)).unwrap_err();
     assert_eq!(
         format!("{}", actual.root_cause()),

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -137,6 +137,8 @@ impl Sodg {
     ///
     /// If vertex `v1` is absent, an `Err` will be returned.
     ///
+    /// If vertex `v1` is not full (i.e. #put was not called to the vertex), `Err` will be returned.
+    ///
     /// If there is no data, an empty `Hex` will be returned, for example:
     ///
     /// ```

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -512,3 +512,14 @@ fn check_for_data_receiving_before_put() -> Result<()> {
     assert_eq!(true, actual.contains("#data: Calling #data before"));
     Ok(())
 }
+
+#[test]
+fn checks_for_put_make_vert_full() -> Result<()> {
+    let mut g = Sodg::empty();
+    g.add(1)?;
+    g.add(2)?;
+    g.bind(1, 2, "Hi, i'm the dog my name is Ruby!")?;
+    g.put(2, Hex::from_str_bytes("Ruby-the-dog"))?;
+    assert!(g.full(2)?);
+    Ok(())
+}

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -251,7 +251,7 @@ impl Sodg {
     /// If the vertex is absent, the method will return `Err`.
     pub fn full(&self, v: u32) -> Result<bool> {
         let vtx = self.vertices.get(&v).context(format!("Can't find ν{v}"))?;
-        Ok(!vtx.data.is_empty())
+        Ok(vtx.full)
     }
 
     /// Split label into two parts.

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -22,7 +22,7 @@ use crate::Edge;
 use crate::Hex;
 use crate::Sodg;
 use crate::Vertex;
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use log::trace;
 use rstest::rstest;
 
@@ -107,7 +107,9 @@ impl Sodg {
             .get_mut(&v)
             .context(format!("Can't find ν{v}"))?;
         if vtx.posted {
-            return Err(anyhow!("The vertex isn't available, #put() was called earlier"));
+            return Err(anyhow!(
+                "The vertex isn't available, #put() was called earlier"
+            ));
         }
         vtx.data = d.clone();
         vtx.posted = true;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -491,6 +491,6 @@ fn checks_for_put_called_once() -> Result<()> {
     g.bind(0, 1, "bar/baz")?;
     g.put(0, Hex::from(42))?;
     let actual = format!("{}", g.put(0, Hex::from(42)).unwrap_err().root_cause());
-    assert_eq!(true, actual.contains("#put() was called earlier"));
+    assert_eq!(true, actual.contains("#put was called earlier"));
     Ok(())
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -519,7 +519,7 @@ fn checks_for_put_make_vert_full() -> Result<()> {
     g.add(1)?;
     g.add(2)?;
     g.bind(1, 2, "Hi, i'm the dog my name is Ruby!")?;
-    g.put(2, Hex::from_str_bytes("Ruby-the-dog"))?;
-    assert!(g.full(2)?);
+    g.put(2, Hex::empty())?;
+    assert!(!g.full(2).unwrap());
     Ok(())
 }

--- a/src/vertex.rs
+++ b/src/vertex.rs
@@ -28,6 +28,7 @@ pub(crate) struct Vertex {
     pub data: Hex,
     pub parents: HashSet<u32>,
     pub taken: bool,
+    pub posted: bool,
 }
 
 impl Vertex {
@@ -46,6 +47,7 @@ impl Vertex {
             data: Hex::empty(),
             parents: HashSet::new(),
             taken: false,
+            posted: false,
         }
     }
 }

--- a/src/vertex.rs
+++ b/src/vertex.rs
@@ -28,7 +28,7 @@ pub(crate) struct Vertex {
     pub data: Hex,
     pub parents: HashSet<u32>,
     pub taken: bool,
-    pub posted: bool,
+    pub full: bool,
 }
 
 impl Vertex {
@@ -47,7 +47,7 @@ impl Vertex {
             data: Hex::empty(),
             parents: HashSet::new(),
             taken: false,
-            posted: false,
+            full: false,
         }
     }
 }


### PR DESCRIPTION
@yegor256 take a look, please 
closes #62 
Here fix for:
- It's only possible to call `put()` once, the second call leads to `Err`

could you write a clarification for:
- Until `put()` is called for a vertex, all `data()` calls return `Err`
- Calling put(Hex::empty()) makes the vertex "full"(see https://github.com/objectionary/sodg/issues/61)