### PR TITLE
refactor: refresh the code base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,21 +48,22 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
+ "bincode_derive",
  "serde",
  "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -595,7 +596,7 @@ version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c97286efc9fe97652f1f821b1b12c13fdec3bca8969f4d2e5967df78de83b594"
 dependencies = [
- "bincode 2.0.1",
+ "bincode",
  "serde",
 ]
 
@@ -1019,7 +1020,7 @@ name = "sodg"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "bincode 1.3.3",
+ "bincode",
  "criterion",
  "ctor",
  "emap",
@@ -1198,6 +1199,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi",
  "libc",
  "winapi",
 ]
@@ -163,25 +163,22 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
 dependencies = [
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -310,12 +307,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -359,52 +356,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
@@ -416,12 +371,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -441,16 +390,24 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
 ]
 
 [[package]]
@@ -485,12 +442,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,21 +467,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi 0.5.0",
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -568,15 +517,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.162"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "log"
@@ -592,9 +541,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "micromap"
-version = "0.0.19"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c97286efc9fe97652f1f821b1b12c13fdec3bca8969f4d2e5967df78de83b594"
+checksum = "18c087666f377f857b49564f8791b481260c67825d6b337e1e38ddf54a985a88"
 dependencies = [
  "bincode",
  "serde",
@@ -659,9 +608,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.72"
+version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -694,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -817,6 +766,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,21 +828,21 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rstest"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2c585be59b6b5dd66a9d2084aa1d8bd52fbdb806eafdeffb52791147862035"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
 dependencies = [
- "futures",
  "futures-timer",
+ "futures-util",
  "rstest_macros",
  "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825ea780781b15345a146be27eaefb05085e337e869bff01b4306a4fd4a9ad5a"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
 dependencies = [
  "cfg-if",
  "glob",
@@ -903,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -918,15 +873,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.40"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -958,18 +913,18 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1081,12 +1036,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -1217,6 +1172,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,15 +1286,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1473,7 +1428,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "xml-builder"
-version = "0.5.3"
+name = "wit-bindgen-rt"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef5f40cd674b9d9814545203f175ac29ffdcb6e006727f4d95797d7badd72e2"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "xml-builder"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c023e38161c176b6ed516e2c398acd755cd19983661eff519b811c01646e10f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,8 @@ tempfile = "3.20.0"
 [[bench]]
 name = "bench"
 harness = false
+
+[lints.clippy]
+all = "warn"
+pedantic = "warn"
+nursery = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,34 +17,34 @@ categories = ["data-structures", "memory-management"]
 gc = []
 
 [dependencies]
-anyhow = "1.0.75"
+anyhow = "1.0.98"
 bincode = { version = "2.0.1", features = ["serde"] }
-ctor = "0.4.0"
-emap = {version = "0.0.13", features = ["serde"] }
+ctor = "0.4.2"
+emap = { version = "0.0.13", features = ["serde"] }
 hex = "0.4.3"
 itertools = "0.14.0"
-lazy_static = "1.4.0"
-libc = "0.2.142"
-log = "0.4.20"
-micromap = { version = "0.0.19", features = ["serde"] }
+lazy_static = "1.5.0"
+libc = "0.2.174"
+log = "0.4.27"
+micromap = { version = "0.1.0", features = ["serde"] }
 microstack = { version = "0.0.7", features = ["serde"] }
 nohash-hasher = "0.2.0"
-openssl = { version = "0.10.68", features = ["vendored"] }
-regex = "1.9.3"
-rstest = "0.23.0"
-rustc-hash = "2.0.0"
-serde = { version = "1.0.162", features = ["derive"] }
+openssl = { version = "0.10.73", features = ["vendored"] }
+regex = "1.11.1"
+rstest = "0.25.0"
+rustc-hash = "2.1.1"
+serde = { version = "1.0.219", features = ["derive"] }
 simple_logger = "5.0.0"
 sxd-document = "0.3.2"
 sxd-xpath = "0.4.2"
 tinymap = "0.4.0"
-xml-builder = "0.5.2"
+xml-builder = "0.5.4"
 
 [dev-dependencies]
-criterion = "0.5.1"
+criterion = "0.6.0"
 fsutils = "0.1.7"
-predicates = "3.0.3"
-tempfile = "3.8.0"
+predicates = "3.1.3"
+tempfile = "3.20.0"
 
 [[bench]]
 name = "bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 [package]
 name = "sodg"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/objectionary/sodg"
 description = "Surging Object DiGraph (SODG)"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ gc = []
 
 [dependencies]
 anyhow = "1.0.75"
-bincode = "1.3.3"
+bincode = { version = "2.0.1", features = ["serde"] }
 ctor = "0.4.0"
 emap = {version = "0.0.13", features = ["serde"] }
 hex = "0.4.3"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -9,7 +9,9 @@
 ///
 /// If you want to run a single benchmark, you can use the command
 /// `cargo bench -- bench_name`, for example `cargo bench -- add_vertices`.
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use sodg::{Hex, Label, Sodg};
 
 fn setup_graph(n: usize) -> Sodg<16> {

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
 // SPDX-License-Identifier: MIT
 
+#![allow(clippy::unit_arg)]
 /// Benchmark Usage:
 ///
 /// `cargo bench --bench bench` will run all benchmarks in this file.

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -13,6 +13,7 @@
 use std::hint::black_box;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+
 use sodg::{Hex, Label, Sodg};
 
 fn setup_graph(n: usize) -> Sodg<16> {

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -35,7 +35,7 @@ fn bench_add_vertices(c: &mut Criterion) {
                     black_box(graph.add(black_box(i)));
                 }
                 black_box(&mut graph);
-            })
+            });
         });
     }
     group.finish();
@@ -58,7 +58,7 @@ fn bench_bind_edges(c: &mut Criterion) {
                     }
                 }
                 black_box(&mut graph);
-            })
+            });
         });
     }
     group.finish();
@@ -77,7 +77,7 @@ fn bench_put(c: &mut Criterion) {
                     );
                 }
                 black_box(&mut graph);
-            })
+            });
         });
     }
     group.finish();
@@ -97,7 +97,7 @@ fn bench_put_and_data(c: &mut Criterion) {
                     _ = black_box(graph.data(black_box(i)));
                 }
                 black_box(&mut graph);
-            })
+            });
         });
     }
     group.finish();

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -9,7 +9,7 @@
 ///
 /// If you want to run a single benchmark, you can use the command
 /// `cargo bench -- bench_name`, for example `cargo bench -- add_vertices`.
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use sodg::{Hex, Label, Sodg};
 
 fn setup_graph(n: usize) -> Sodg<16> {

--- a/src/bin/malloc.rs
+++ b/src/bin/malloc.rs
@@ -72,6 +72,16 @@ pub fn on_heap(total: usize) -> (i64, Duration) {
     (std::hint::black_box(sum), start.elapsed())
 }
 
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)]
+fn u128_to_f64(x: u128) -> Option<f64> {
+    let res = x as f64;
+    (res as u128 == x).then_some(res)
+}
+
 fn main() {
     let total = 1_000_000;
     let (s1, d1) = on_graph(total);
@@ -83,14 +93,4 @@ fn main() {
     println!("gain: {:.2}x", d2_nanos / d1_nanos);
     println!("loss: {:.2}x", d1_nanos / d2_nanos);
     assert_eq!(s1, s2);
-}
-
-#[allow(
-    clippy::cast_possible_truncation,
-    clippy::cast_precision_loss,
-    clippy::cast_sign_loss
-)]
-fn u128_to_f64(x: u128) -> Option<f64> {
-    let res = x as f64;
-    (res as u128 == x).then_some(res)
 }

--- a/src/bin/malloc.rs
+++ b/src/bin/malloc.rs
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
 // SPDX-License-Identifier: MIT
 
-use sodg::{Hex, Label, Sodg};
 use std::time::{Duration, Instant};
+
+use sodg::{Hex, Label, Sodg};
 
 trait Book {
     fn price(&self) -> i64;
@@ -70,7 +71,7 @@ pub fn on_heap(total: usize) -> (i64, Duration) {
 }
 
 fn main() {
-    let total = 1000000;
+    let total = 1_000_000;
     let (s1, d1) = on_graph(total);
     println!("on_graph: {d1:?}");
     let (s2, d2) = on_heap(total);

--- a/src/bin/malloc.rs
+++ b/src/bin/malloc.rs
@@ -77,10 +77,20 @@ fn main() {
     let (s1, d1) = on_graph(total);
     println!("on_graph: {d1:?}");
     let (s2, d2) = on_heap(total);
-    let d1_nanos = f64::from(u32::try_from(d1.as_nanos()).unwrap());
-    let d2_nanos = f64::from(u32::try_from(d2.as_nanos()).unwrap());
+    let d1_nanos = u128_to_f64(d1.as_nanos()).unwrap();
+    let d2_nanos = u128_to_f64(d2.as_nanos()).unwrap();
     println!("on_heap: {d2_nanos:?}");
     println!("gain: {:.2}x", d2_nanos / d1_nanos);
     println!("loss: {:.2}x", d1_nanos / d2_nanos);
     assert_eq!(s1, s2);
+}
+
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)]
+fn u128_to_f64(x: u128) -> Option<f64> {
+    let res = x as f64;
+    (res as u128 == x).then_some(res)
 }

--- a/src/bin/malloc.rs
+++ b/src/bin/malloc.rs
@@ -29,6 +29,8 @@ impl Book for Discounted {
     }
 }
 
+#[allow(clippy::missing_panics_doc)]
+#[must_use]
 pub fn on_graph(total: usize) -> (i64, Duration) {
     let mut g: Sodg<16> = Sodg::empty(total * 4);
     g.add(0);
@@ -58,14 +60,14 @@ pub fn on_graph(total: usize) -> (i64, Duration) {
     (std::hint::black_box(sum), start.elapsed())
 }
 
+#[must_use]
 pub fn on_heap(total: usize) -> (i64, Duration) {
     let mut sum = 0;
     let start = Instant::now();
     for _ in 0..total {
         let prime = std::hint::black_box(Box::new(Prime { usd: 42 }));
         let discounted = std::hint::black_box(Box::new(Discounted { book: prime }));
-        let price = discounted.price();
-        sum += price;
+        sum += discounted.price();
     }
     (std::hint::black_box(sum), start.elapsed())
 }
@@ -75,8 +77,10 @@ fn main() {
     let (s1, d1) = on_graph(total);
     println!("on_graph: {d1:?}");
     let (s2, d2) = on_heap(total);
-    println!("on_heap: {d2:?}");
-    println!("gain: {:.2}x", d2.as_nanos() as f64 / d1.as_nanos() as f64);
-    println!("loss: {:.2}x", d1.as_nanos() as f64 / d2.as_nanos() as f64);
+    let d1_nanos = f64::from(u32::try_from(d1.as_nanos()).unwrap());
+    let d2_nanos = f64::from(u32::try_from(d2.as_nanos()).unwrap());
+    println!("on_heap: {d2_nanos:?}");
+    println!("gain: {:.2}x", d2_nanos / d1_nanos);
+    println!("loss: {:.2}x", d1_nanos / d2_nanos);
     assert_eq!(s1, s2);
 }

--- a/src/bin/malloc.rs
+++ b/src/bin/malloc.rs
@@ -72,9 +72,9 @@ pub fn on_heap(total: usize) -> (i64, Duration) {
 fn main() {
     let total = 1000000;
     let (s1, d1) = on_graph(total);
-    println!("on_graph: {:?}", d1);
+    println!("on_graph: {d1:?}");
     let (s2, d2) = on_heap(total);
-    println!("on_heap: {:?}", d2);
+    println!("on_heap: {d2:?}");
     println!("gain: {:.2}x", d2.as_nanos() as f64 / d1.as_nanos() as f64);
     println!("loss: {:.2}x", d1.as_nanos() as f64 / d2.as_nanos() as f64);
     assert_eq!(s1, s2);

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -29,6 +29,7 @@ fn makes_a_clone() {
 }
 
 #[test]
+#[allow(clippy::redundant_clone)]
 fn makes_an_empty_clone() {
     let g: Sodg<16> = Sodg::empty(256);
     let c = g.clone();

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -16,22 +16,25 @@ impl<const N: usize> Clone for Sodg<N> {
 }
 
 #[cfg(test)]
-use crate::Label;
+mod tests {
+    use super::*;
+    use crate::Label;
 
-#[test]
-fn makes_a_clone() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(1);
-    g.add(42);
-    g.bind(1, 42, Label::Alpha(0));
-    let c = g.clone();
-    assert_eq!(2, c.len());
-}
+    #[test]
+    fn makes_a_clone() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(1);
+        g.add(42);
+        g.bind(1, 42, Label::Alpha(0));
+        let c = g.clone();
+        assert_eq!(2, c.len());
+    }
 
-#[test]
-#[allow(clippy::redundant_clone)]
-fn makes_an_empty_clone() {
-    let g: Sodg<16> = Sodg::empty(256);
-    let c = g.clone();
-    assert_eq!(0, c.len());
+    #[test]
+    #[allow(clippy::redundant_clone)]
+    fn makes_an_empty_clone() {
+        let g: Sodg<16> = Sodg::empty(256);
+        let c = g.clone();
+        assert_eq!(0, c.len());
+    }
 }

--- a/src/ctors.rs
+++ b/src/ctors.rs
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
 // SPDX-License-Identifier: MIT
 
-use crate::{Hex, MAX_BRANCHES, Persistence, Sodg, Vertex};
 use emap::Map;
+
+use crate::{Hex, MAX_BRANCHES, Persistence, Sodg, Vertex};
 
 impl<const N: usize> Sodg<N> {
     /// Make an empty [`Sodg`], with no vertices and no edges.
@@ -26,10 +27,8 @@ impl<const N: usize> Sodg<N> {
             branches: Map::with_capacity_some(MAX_BRANCHES, microstack::Stack::new()),
             next_v: 0,
         };
-        g.branches
-            .insert(0, microstack::Stack::from_vec([0].to_vec()));
-        g.branches
-            .insert(1, microstack::Stack::from_vec([0].to_vec()));
+        g.branches.insert(0, microstack::Stack::from_vec(vec![0]));
+        g.branches.insert(1, microstack::Stack::from_vec(vec![0]));
         g
     }
 }

--- a/src/ctors.rs
+++ b/src/ctors.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
 // SPDX-License-Identifier: MIT
 
-use crate::{Hex, Persistence, Sodg, Vertex, MAX_BRANCHES};
+use crate::{Hex, MAX_BRANCHES, Persistence, Sodg, Vertex};
 use emap::Map;
 
 impl<const N: usize> Sodg<N> {

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
 // SPDX-License-Identifier: MIT
 
+use std::fmt::{self, Debug, Display, Formatter};
+
+use anyhow::{Context as _, Result};
+
 use crate::{Persistence, Sodg};
-use anyhow::{Context, Result};
-use std::fmt;
-use std::fmt::{Debug, Display, Formatter};
 
 impl<const N: usize> Display for Sodg<N> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -80,11 +80,7 @@ digraph {
                     },
                     match e.0 {
                         Label::Greek(g) => {
-                            if *g == 'π' {
-                                ",style=dashed"
-                            } else {
-                                ""
-                            }
+                            if *g == 'π' { ",style=dashed" } else { "" }
                         }
                         _ => {
                             ""

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
 // SPDX-License-Identifier: MIT
 
-use crate::{Label, Persistence, Sodg};
 use itertools::Itertools;
+
+use crate::{Label, Persistence, Sodg};
 
 impl<const N: usize> Sodg<N> {
     /// Print SODG as a DOT graph.

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -11,7 +11,7 @@ impl<const N: usize> Sodg<N> {
     /// For example, for this code:
     ///
     /// ```
-    /// use std::str::FromStr;
+    /// use std::str::FromStr as _;
     /// use sodg::{Hex, Label};
     /// use sodg::Sodg;
     /// let mut g : Sodg<16> = Sodg::empty(256);

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -997,5 +997,5 @@ fn test_from_str_bytes_correctly() {
     let a = Hex::from_str_bytes("Hello, world!");
     let b = &a[5..];
     let res = String::from_utf8(b.to_vec()).unwrap();
-    assert_eq!(&res, ", world!")
+    assert_eq!(&res, ", world!");
 }

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
 // SPDX-License-Identifier: MIT
 
-use crate::{Hex, HEX_SIZE};
+use crate::{HEX_SIZE, Hex};
 use anyhow::{Context, Result};
 use std::fmt::{Debug, Display, Formatter};
 use std::ops::{

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -1,10 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
 // SPDX-License-Identifier: MIT
 
-use crate::Sodg;
-use anyhow::{Context, Result};
-use itertools::Itertools;
 use std::collections::HashSet;
+
+use anyhow::{Context as _, Result};
+use itertools::Itertools;
+
+use crate::Sodg;
 
 impl<const N: usize> Sodg<N> {
     /// Find an object by the provided locator and print its tree
@@ -20,7 +22,7 @@ impl<const N: usize> Sodg<N> {
         Ok(format!(
             "ν{}\n{}",
             v,
-            self.inspect_v(v, &mut seen)?.join("\n")
+            self.inspect_v(v, &mut seen)?.join("\n"),
         ))
     }
 
@@ -40,10 +42,10 @@ impl<const N: usize> Sodg<N> {
                     e.0,
                     e.1,
                     if skip {
-                        "…".to_string()
+                        "…".to_owned()
                     } else {
                         String::new()
-                    }
+                    },
                 );
                 lines.push(line);
                 if !skip {
@@ -59,18 +61,19 @@ impl<const N: usize> Sodg<N> {
 }
 
 #[cfg(test)]
-use crate::Hex;
+mod tests {
+    use super::*;
+    use crate::Hex;
+    use crate::Label;
 
-#[cfg(test)]
-use crate::Label;
-
-#[test]
-fn inspects_simple_object() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(0);
-    g.put(0, &Hex::from_str_bytes("hello"));
-    g.add(1);
-    let txt = g.inspect(0).unwrap();
-    g.bind(0, 1, Label::Alpha(0));
-    assert_ne!(String::new(), txt);
+    #[test]
+    fn inspects_simple_object() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.put(0, &Hex::from_str_bytes("hello"));
+        g.add(1);
+        let txt = g.inspect(0).unwrap();
+        g.bind(0, 1, Label::Alpha(0));
+        assert_ne!(String::new(), txt);
+    }
 }

--- a/src/label.rs
+++ b/src/label.rs
@@ -1,11 +1,14 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
 // SPDX-License-Identifier: MIT
 
-use crate::Label;
-use anyhow::anyhow;
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
+
+use anyhow::bail;
+use rstest::rstest;
+
+use crate::Label;
 
 impl FromStr for Label {
     type Err = anyhow::Error;
@@ -21,7 +24,7 @@ impl FromStr for Label {
             let mut a: [char; 8] = [' '; 8];
             for (i, c) in v.into_iter().enumerate() {
                 if i > 7 {
-                    return Err(anyhow!("Can't parse more than {} chars", a.len()));
+                    bail!("Can't parse more than {} chars", a.len());
                 }
                 a[i] = c;
             }
@@ -39,7 +42,7 @@ impl Display for Label {
 impl Debug for Label {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match *self {
-            Self::Greek(c) => f.write_str(format!("{c}").as_str()),
+            Self::Greek(c) => f.write_str(c.to_string().as_str()),
             Self::Alpha(i) => f.write_str(format!("α{i}").as_str()),
             Self::Str(a) => {
                 f.write_str(a.iter().filter(|c| **c != ' ').collect::<String>().as_str())
@@ -47,8 +50,6 @@ impl Debug for Label {
         }
     }
 }
-
-use rstest::rstest;
 
 #[rstest]
 #[case("𝜑")]

--- a/src/label.rs
+++ b/src/label.rs
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
 // SPDX-License-Identifier: MIT
 
-use std::fmt;
-use std::fmt::{Debug, Display, Formatter};
+use std::fmt::{self, Debug, Display, Formatter};
 use std::str::FromStr;
 
 use anyhow::bail;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! di-graph with two vertices and an edge between them:
 //!
 //! ```
-//! use std::str::FromStr;
+//! use std::str::FromStr as _;
 //! use sodg::{Label, Sodg};
 //! let mut sodg : Sodg<16> = Sodg::empty(256);
 //! sodg.add(0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,10 @@
 #![allow(clippy::multiple_inherent_impl)]
 #![allow(clippy::multiple_crate_versions)]
 
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
 mod clone;
 mod ctors;
 mod debug;
@@ -41,9 +45,6 @@ mod script;
 mod serialization;
 mod slice;
 mod xml;
-
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 const HEX_SIZE: usize = 8;
 const MAX_BRANCHES: usize = 16;
@@ -150,14 +151,11 @@ struct Vertex<const N: usize> {
 }
 
 #[cfg(test)]
-use simple_logger::SimpleLogger;
-
-#[cfg(test)]
-use log::LevelFilter;
-
-#[cfg(test)]
 #[ctor::ctor]
 fn init() {
+    use log::LevelFilter;
+    use simple_logger::SimpleLogger;
+
     SimpleLogger::new()
         .without_timestamps()
         .with_level(LevelFilter::Trace)

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1,10 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
 // SPDX-License-Identifier: MIT
 
-use crate::{Label, Persistence, Sodg};
-use anyhow::{Result, anyhow};
-use log::debug;
 use std::collections::{HashMap, HashSet};
+
+use anyhow::{Result, bail};
+use log::debug;
+
+use crate::{Label, Persistence, Sodg};
 
 impl<const N: usize> Sodg<N> {
     /// Merge another graph into the current one.
@@ -34,7 +36,7 @@ impl<const N: usize> Sodg<N> {
                 &HashSet::from_iter(must.clone()) - &HashSet::from_iter(seen.clone());
             let mut ordered: Vec<usize> = missed.into_iter().collect();
             ordered.sort_unstable();
-            return Err(anyhow!(
+            bail!(
                 "Just {merged} vertices merged, out of {scope} (must={}, seen={}); maybe the right graph was not a tree? {} missed: {}",
                 must.len(),
                 seen.len(),
@@ -43,13 +45,13 @@ impl<const N: usize> Sodg<N> {
                     .iter()
                     .map(|v| format!("ν{v}"))
                     .collect::<Vec<String>>()
-                    .join(", ")
-            ));
+                    .join(", "),
+            );
         }
         debug!(
             "Merged all {merged} vertices into SODG of {}, making it have {} after the merge",
             before,
-            self.len()
+            self.len(),
         );
         Ok(())
     }
@@ -124,7 +126,7 @@ impl<const N: usize> Sodg<N> {
             assert!(
                 self.kid(left, e.0).is_none(),
                 "Can't merge ν{right} into ν{left}, due to conflict in '{}'",
-                e.0
+                e.0,
             );
             self.bind(left, e.1, e.0);
         }
@@ -133,256 +135,260 @@ impl<const N: usize> Sodg<N> {
 }
 
 #[cfg(test)]
-use std::str::FromStr;
+mod tests {
+    use std::str::FromStr;
 
-#[test]
-fn merges_two_graphs() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(0);
-    g.add(1);
-    g.bind(0, 1, Label::from_str("foo").unwrap());
-    let mut extra = Sodg::empty(256);
-    extra.add(0);
-    extra.add(1);
-    extra.bind(0, 1, Label::from_str("bar").unwrap());
-    g.merge(&extra, 0, 0).unwrap();
-    assert_eq!(3, g.len());
-    assert_eq!(1, g.kid(0, Label::from_str("foo").unwrap()).unwrap());
-    assert_eq!(2, g.kid(0, Label::from_str("bar").unwrap()).unwrap());
-}
+    use super::*;
 
-#[test]
-fn merges_two_non_trees() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    let mut extra = Sodg::empty(256);
-    extra.add(0);
-    extra.add(42);
-    extra.add(2);
-    extra.add(13);
-    let r = g.merge(&extra, 0, 0);
-    assert!(r.is_err());
-    let msg = r.err().unwrap().to_string();
-    assert!(msg.contains("ν2, ν13, ν42"), "{}", msg);
-}
+    #[test]
+    fn merges_two_graphs() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(1);
+        g.bind(0, 1, Label::from_str("foo").unwrap());
+        let mut extra = Sodg::empty(256);
+        extra.add(0);
+        extra.add(1);
+        extra.bind(0, 1, Label::from_str("bar").unwrap());
+        g.merge(&extra, 0, 0).unwrap();
+        assert_eq!(3, g.len());
+        assert_eq!(1, g.kid(0, Label::from_str("foo").unwrap()).unwrap());
+        assert_eq!(2, g.kid(0, Label::from_str("bar").unwrap()).unwrap());
+    }
 
-#[test]
-fn merges_a_loop() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(0);
-    g.add(1);
-    g.bind(0, 1, Label::from_str("a").unwrap());
-    g.add(2);
-    g.bind(1, 2, Label::from_str("b").unwrap());
-    let mut extra = Sodg::empty(256);
-    extra.add(0);
-    extra.add(4);
-    extra.bind(0, 4, Label::from_str("c").unwrap());
-    extra.add(3);
-    extra.bind(0, 3, Label::from_str("a").unwrap());
-    extra.bind(4, 3, Label::from_str("d").unwrap());
-    extra.add(5);
-    extra.bind(3, 5, Label::from_str("e").unwrap());
-    g.merge(&extra, 0, 0).unwrap();
-    assert_eq!(5, g.len());
-    assert_eq!(1, g.kid(0, Label::from_str("a").unwrap()).unwrap());
-    assert_eq!(2, g.kid(1, Label::from_str("b").unwrap()).unwrap());
-    // assert_eq!(3, g.kid(0, "c").unwrap());
-    // assert_eq!(1, g.kid(3, "d").unwrap());
-    // assert_eq!(5, g.kid(1, "e").unwrap());
-}
+    #[test]
+    fn merges_two_non_trees() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        let mut extra = Sodg::empty(256);
+        extra.add(0);
+        extra.add(42);
+        extra.add(2);
+        extra.add(13);
+        let r = g.merge(&extra, 0, 0);
+        assert!(r.is_err());
+        let msg = r.err().unwrap().to_string();
+        assert!(msg.contains("ν2, ν13, ν42"), "{}", msg);
+    }
 
-#[test]
-fn avoids_simple_duplicates() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(0);
-    g.add(5);
-    g.bind(0, 5, Label::from_str("foo").unwrap());
-    let mut extra = Sodg::empty(256);
-    extra.add(0);
-    extra.add(1);
-    extra.bind(0, 1, Label::from_str("foo").unwrap());
-    extra.add(2);
-    extra.bind(1, 2, Label::from_str("bar").unwrap());
-    g.merge(&extra, 0, 0).unwrap();
-    assert_eq!(3, g.len());
-    assert_eq!(5, g.kid(0, Label::from_str("foo").unwrap()).unwrap());
-    assert_eq!(1, g.kid(5, Label::from_str("bar").unwrap()).unwrap());
-}
+    #[test]
+    fn merges_a_loop() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(1);
+        g.bind(0, 1, Label::from_str("a").unwrap());
+        g.add(2);
+        g.bind(1, 2, Label::from_str("b").unwrap());
+        let mut extra = Sodg::empty(256);
+        extra.add(0);
+        extra.add(4);
+        extra.bind(0, 4, Label::from_str("c").unwrap());
+        extra.add(3);
+        extra.bind(0, 3, Label::from_str("a").unwrap());
+        extra.bind(4, 3, Label::from_str("d").unwrap());
+        extra.add(5);
+        extra.bind(3, 5, Label::from_str("e").unwrap());
+        g.merge(&extra, 0, 0).unwrap();
+        assert_eq!(5, g.len());
+        assert_eq!(1, g.kid(0, Label::from_str("a").unwrap()).unwrap());
+        assert_eq!(2, g.kid(1, Label::from_str("b").unwrap()).unwrap());
+        // assert_eq!(3, g.kid(0, "c").unwrap());
+        // assert_eq!(1, g.kid(3, "d").unwrap());
+        // assert_eq!(5, g.kid(1, "e").unwrap());
+    }
 
-#[test]
-fn keeps_existing_vertices_intact() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(0);
-    g.add(1);
-    g.bind(0, 1, Label::from_str("foo").unwrap());
-    g.add(2);
-    g.bind(1, 2, Label::from_str("bar").unwrap());
-    g.add(3);
-    g.bind(2, 3, Label::from_str("zzz").unwrap());
-    let mut extra = Sodg::empty(256);
-    extra.add(0);
-    extra.add(5);
-    extra.bind(0, 5, Label::from_str("foo").unwrap());
-    g.merge(&extra, 0, 0).unwrap();
-    assert_eq!(4, g.len());
-    assert_eq!(1, g.kid(0, Label::from_str("foo").unwrap()).unwrap());
-    assert_eq!(2, g.kid(1, Label::from_str("bar").unwrap()).unwrap());
-    assert_eq!(3, g.kid(2, Label::from_str("zzz").unwrap()).unwrap());
-}
+    #[test]
+    fn avoids_simple_duplicates() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(5);
+        g.bind(0, 5, Label::from_str("foo").unwrap());
+        let mut extra = Sodg::empty(256);
+        extra.add(0);
+        extra.add(1);
+        extra.bind(0, 1, Label::from_str("foo").unwrap());
+        extra.add(2);
+        extra.bind(1, 2, Label::from_str("bar").unwrap());
+        g.merge(&extra, 0, 0).unwrap();
+        assert_eq!(3, g.len());
+        assert_eq!(5, g.kid(0, Label::from_str("foo").unwrap()).unwrap());
+        assert_eq!(1, g.kid(5, Label::from_str("bar").unwrap()).unwrap());
+    }
 
-#[test]
-fn merges_singletons() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(13);
-    let mut extra = Sodg::empty(256);
-    extra.add(13);
-    g.merge(&extra, 13, 13).unwrap();
-    assert_eq!(1, g.len());
-}
+    #[test]
+    fn keeps_existing_vertices_intact() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(1);
+        g.bind(0, 1, Label::from_str("foo").unwrap());
+        g.add(2);
+        g.bind(1, 2, Label::from_str("bar").unwrap());
+        g.add(3);
+        g.bind(2, 3, Label::from_str("zzz").unwrap());
+        let mut extra = Sodg::empty(256);
+        extra.add(0);
+        extra.add(5);
+        extra.bind(0, 5, Label::from_str("foo").unwrap());
+        g.merge(&extra, 0, 0).unwrap();
+        assert_eq!(4, g.len());
+        assert_eq!(1, g.kid(0, Label::from_str("foo").unwrap()).unwrap());
+        assert_eq!(2, g.kid(1, Label::from_str("bar").unwrap()).unwrap());
+        assert_eq!(3, g.kid(2, Label::from_str("zzz").unwrap()).unwrap());
+    }
 
-#[test]
-fn merges_simple_loop() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(1);
-    g.add(2);
-    g.bind(1, 2, Label::from_str("foo").unwrap());
-    g.bind(2, 1, Label::from_str("bar").unwrap());
-    let extra = g.clone();
-    g.merge(&extra, 1, 1).unwrap();
-    assert_eq!(extra.len(), g.len());
-}
+    #[test]
+    fn merges_singletons() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(13);
+        let mut extra = Sodg::empty(256);
+        extra.add(13);
+        g.merge(&extra, 13, 13).unwrap();
+        assert_eq!(1, g.len());
+    }
 
-#[test]
-fn merges_large_loop() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(1);
-    g.add(2);
-    g.add(3);
-    g.add(4);
-    g.bind(1, 2, Label::from_str("a").unwrap());
-    g.bind(2, 3, Label::from_str("b").unwrap());
-    g.bind(3, 4, Label::from_str("c").unwrap());
-    g.bind(4, 1, Label::from_str("d").unwrap());
-    let extra = g.clone();
-    g.merge(&extra, 1, 1).unwrap();
-    assert_eq!(extra.len(), g.len());
-}
+    #[test]
+    fn merges_simple_loop() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(1);
+        g.add(2);
+        g.bind(1, 2, Label::from_str("foo").unwrap());
+        g.bind(2, 1, Label::from_str("bar").unwrap());
+        let extra = g.clone();
+        g.merge(&extra, 1, 1).unwrap();
+        assert_eq!(extra.len(), g.len());
+    }
 
-#[cfg(test)]
-use crate::Hex;
+    #[test]
+    fn merges_large_loop() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(1);
+        g.add(2);
+        g.add(3);
+        g.add(4);
+        g.bind(1, 2, Label::from_str("a").unwrap());
+        g.bind(2, 3, Label::from_str("b").unwrap());
+        g.bind(3, 4, Label::from_str("c").unwrap());
+        g.bind(4, 1, Label::from_str("d").unwrap());
+        let extra = g.clone();
+        g.merge(&extra, 1, 1).unwrap();
+        assert_eq!(extra.len(), g.len());
+    }
 
-#[test]
-fn merges_data() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(1);
-    let mut extra = Sodg::empty(256);
-    extra.add(1);
-    extra.put(1, &Hex::from(42_i64));
-    g.merge(&extra, 1, 1).unwrap();
-    assert_eq!(42, g.data(1).unwrap().to_i64().unwrap());
-}
+    #[cfg(test)]
+    use crate::Hex;
 
-#[test]
-fn understands_same_name_kids() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(0);
-    g.add(1);
-    g.bind(0, 1, Label::from_str("a").unwrap());
-    g.add(2);
-    g.bind(1, 2, Label::from_str("x").unwrap());
-    let mut extra = Sodg::empty(256);
-    extra.add(0);
-    extra.add(1);
-    extra.bind(0, 1, Label::from_str("b").unwrap());
-    extra.add(2);
-    extra.bind(1, 2, Label::from_str("x").unwrap());
-    g.merge(&extra, 0, 0).unwrap();
-    assert_eq!(5, g.len());
-    assert_eq!(1, g.kid(0, Label::from_str("a").unwrap()).unwrap());
-    assert_eq!(2, g.kid(1, Label::from_str("x").unwrap()).unwrap());
-}
+    #[test]
+    fn merges_data() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(1);
+        let mut extra = Sodg::empty(256);
+        extra.add(1);
+        extra.put(1, &Hex::from(42_i64));
+        g.merge(&extra, 1, 1).unwrap();
+        assert_eq!(42, g.data(1).unwrap().to_i64().unwrap());
+    }
 
-#[test]
-fn merges_into_empty_graph() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(1);
-    let mut extra = Sodg::empty(256);
-    extra.add(1);
-    extra.add(2);
-    extra.add(3);
-    extra.bind(1, 2, Label::from_str("a").unwrap());
-    extra.bind(2, 3, Label::from_str("b").unwrap());
-    extra.bind(3, 1, Label::from_str("c").unwrap());
-    g.merge(&extra, 1, 1).unwrap();
-    assert_eq!(3, g.len());
-    assert_eq!(0, g.kid(1, Label::from_str("a").unwrap()).unwrap());
-}
+    #[test]
+    fn understands_same_name_kids() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(1);
+        g.bind(0, 1, Label::from_str("a").unwrap());
+        g.add(2);
+        g.bind(1, 2, Label::from_str("x").unwrap());
+        let mut extra = Sodg::empty(256);
+        extra.add(0);
+        extra.add(1);
+        extra.bind(0, 1, Label::from_str("b").unwrap());
+        extra.add(2);
+        extra.bind(1, 2, Label::from_str("x").unwrap());
+        g.merge(&extra, 0, 0).unwrap();
+        assert_eq!(5, g.len());
+        assert_eq!(1, g.kid(0, Label::from_str("a").unwrap()).unwrap());
+        assert_eq!(2, g.kid(1, Label::from_str("x").unwrap()).unwrap());
+    }
 
-#[test]
-fn mixed_injection() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(4);
-    let mut extra = Sodg::empty(256);
-    extra.add(4);
-    extra.put(4, &Hex::from(4));
-    extra.add(5);
-    extra.put(5, &Hex::from(5));
-    extra.bind(4, 5, Label::from_str("b").unwrap());
-    g.merge(&extra, 4, 4).unwrap();
-    assert_eq!(2, g.len());
-}
+    #[test]
+    fn merges_into_empty_graph() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(1);
+        let mut extra = Sodg::empty(256);
+        extra.add(1);
+        extra.add(2);
+        extra.add(3);
+        extra.bind(1, 2, Label::from_str("a").unwrap());
+        extra.bind(2, 3, Label::from_str("b").unwrap());
+        extra.bind(3, 1, Label::from_str("c").unwrap());
+        g.merge(&extra, 1, 1).unwrap();
+        assert_eq!(3, g.len());
+        assert_eq!(0, g.kid(1, Label::from_str("a").unwrap()).unwrap());
+    }
 
-#[test]
-fn zero_to_zero() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(0);
-    g.add(1);
-    g.bind(0, 1, Label::from_str("a").unwrap());
-    g.bind(1, 0, Label::from_str("back").unwrap());
-    g.add(2);
-    g.bind(0, 2, Label::from_str("b").unwrap());
-    let mut extra = Sodg::empty(256);
-    extra.add(0);
-    extra.add(1);
-    extra.bind(0, 1, Label::from_str("c").unwrap());
-    extra.bind(1, 0, Label::from_str("back").unwrap());
-    g.merge(&extra, 0, 0).unwrap();
-    assert_eq!(4, g.len());
-}
+    #[test]
+    fn mixed_injection() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(4);
+        let mut extra = Sodg::empty(256);
+        extra.add(4);
+        extra.put(4, &Hex::from(4));
+        extra.add(5);
+        extra.put(5, &Hex::from(5));
+        extra.bind(4, 5, Label::from_str("b").unwrap());
+        g.merge(&extra, 4, 4).unwrap();
+        assert_eq!(2, g.len());
+    }
 
-#[test]
-fn finds_siblings() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(0);
-    g.add(1);
-    g.bind(0, 1, Label::from_str("a").unwrap());
-    g.add(2);
-    g.bind(0, 2, Label::from_str("b").unwrap());
-    let mut extra = Sodg::empty(256);
-    extra.add(0);
-    extra.add(1);
-    extra.bind(0, 1, Label::from_str("b").unwrap());
-    g.merge(&extra, 0, 0).unwrap();
-    assert_eq!(3, g.len());
-}
+    #[test]
+    fn zero_to_zero() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(1);
+        g.bind(0, 1, Label::from_str("a").unwrap());
+        g.bind(1, 0, Label::from_str("back").unwrap());
+        g.add(2);
+        g.bind(0, 2, Label::from_str("b").unwrap());
+        let mut extra = Sodg::empty(256);
+        extra.add(0);
+        extra.add(1);
+        extra.bind(0, 1, Label::from_str("c").unwrap());
+        extra.bind(1, 0, Label::from_str("back").unwrap());
+        g.merge(&extra, 0, 0).unwrap();
+        assert_eq!(4, g.len());
+    }
 
-#[cfg(test)]
-use crate::Script;
+    #[test]
+    fn finds_siblings() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(1);
+        g.bind(0, 1, Label::from_str("a").unwrap());
+        g.add(2);
+        g.bind(0, 2, Label::from_str("b").unwrap());
+        let mut extra = Sodg::empty(256);
+        extra.add(0);
+        extra.add(1);
+        extra.bind(0, 1, Label::from_str("b").unwrap());
+        g.merge(&extra, 0, 0).unwrap();
+        assert_eq!(3, g.len());
+    }
 
-#[test]
-fn two_big_graphs() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    Script::from_str(
-        "ADD(0); ADD(1); BIND(0, 1, foo);
-        ADD(2); BIND(0, 1, alpha);
-        BIND(1, 0, back);",
-    )
-    .deploy_to(&mut g)
-    .unwrap();
-    let mut extra = Sodg::empty(256);
-    Script::from_str("ADD(0); ADD(1); BIND(0, 1, bar); BIND(1, 0, back);")
-        .deploy_to(&mut extra)
+    #[cfg(test)]
+    use crate::Script;
+
+    #[test]
+    fn two_big_graphs() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        Script::from_str(
+            "ADD(0); ADD(1); BIND(0, 1, foo);
+            ADD(2); BIND(0, 1, alpha);
+            BIND(1, 0, back);",
+        )
+        .deploy_to(&mut g)
         .unwrap();
-    g.merge(&extra, 0, 0).unwrap();
-    assert_eq!(4, g.len());
+        let mut extra = Sodg::empty(256);
+        Script::from_str("ADD(0); ADD(1); BIND(0, 1, bar); BIND(1, 0, back);")
+            .deploy_to(&mut extra)
+            .unwrap();
+        g.merge(&extra, 0, 0).unwrap();
+        assert_eq!(4, g.len());
+    }
 }

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use crate::{Label, Persistence, Sodg};
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use log::debug;
 use std::collections::{HashMap, HashSet};
 
@@ -36,8 +36,14 @@ impl<const N: usize> Sodg<N> {
             ordered.sort_unstable();
             return Err(anyhow!(
                 "Just {merged} vertices merged, out of {scope} (must={}, seen={}); maybe the right graph was not a tree? {} missed: {}",
-                must.len(), seen.len(),
-                ordered.len(), ordered.iter().map(|v| format!("ν{v}")).collect::<Vec<String>>().join(", ")
+                must.len(),
+                seen.len(),
+                ordered.len(),
+                ordered
+                    .iter()
+                    .map(|v| format!("ν{v}"))
+                    .collect::<Vec<String>>()
+                    .join(", ")
             ));
         }
         debug!(

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -136,7 +136,7 @@ impl<const N: usize> Sodg<N> {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::str::FromStr as _;
 
     use super::*;
 

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -27,8 +27,13 @@ impl<const N: usize> Sodg<N> {
     }
 }
 
-#[test]
-fn counts_vertices() {
-    let g: Sodg<16> = Sodg::empty(256);
-    assert_eq!(0, g.len());
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counts_vertices() {
+        let g: Sodg<16> = Sodg::empty(256);
+        assert_eq!(0, g.len());
+    }
 }

--- a/src/next.rs
+++ b/src/next.rs
@@ -29,44 +29,49 @@ impl<const N: usize> Sodg<N> {
     }
 }
 
-#[test]
-fn simple_next_id() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    assert_eq!(0, g.next_id());
-    assert_eq!(1, g.next_id());
-    assert_eq!(2, g.next_id());
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[test]
-fn calculates_next_id() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(0);
-    g.add(42);
-    assert_eq!(1, g.next_id());
-    assert_eq!(2, g.next_id());
-}
+    #[test]
+    fn simple_next_id() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        assert_eq!(0, g.next_id());
+        assert_eq!(1, g.next_id());
+        assert_eq!(2, g.next_id());
+    }
 
-#[test]
-fn next_id_after_inject() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(1);
-    assert_eq!(0, g.next_id());
-    assert_eq!(2, g.next_id());
-}
+    #[test]
+    fn calculates_next_id() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(42);
+        assert_eq!(1, g.next_id());
+        assert_eq!(2, g.next_id());
+    }
 
-#[test]
-fn next_id_after_sequence() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(0);
-    g.add(1);
-    assert_eq!(2, g.next_id());
-    assert_eq!(3, g.next_id());
-}
+    #[test]
+    fn next_id_after_inject() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(1);
+        assert_eq!(0, g.next_id());
+        assert_eq!(2, g.next_id());
+    }
 
-#[test]
-fn next_id_after_zero() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(0);
-    assert_eq!(1, g.next_id());
-    assert_eq!(2, g.next_id());
+    #[test]
+    fn next_id_after_sequence() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(1);
+        assert_eq!(2, g.next_id());
+        assert_eq!(3, g.next_id());
+    }
+
+    #[test]
+    fn next_id_after_zero() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        assert_eq!(1, g.next_id());
+        assert_eq!(2, g.next_id());
+    }
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -14,7 +14,7 @@ impl<const N: usize> Sodg<N> {
     /// For example:
     ///
     /// ```
-    /// use std::str::FromStr;
+    /// use std::str::FromStr as _;
     /// use sodg::{Label, Sodg};
     /// let mut g : Sodg<16> = Sodg::empty(256);
     /// g.add(0);
@@ -39,7 +39,7 @@ impl<const N: usize> Sodg<N> {
     /// For example:
     ///
     /// ```
-    /// use std::str::FromStr;
+    /// use std::str::FromStr as _;
     /// use sodg::{Label, Sodg};
     /// let mut g : Sodg<16> = Sodg::empty(256);
     /// g.add(0);
@@ -198,7 +198,7 @@ impl<const N: usize> Sodg<N> {
     /// For example:
     ///
     /// ```
-    /// use std::str::FromStr;
+    /// use std::str::FromStr as _;
     /// use sodg::{Label, Sodg};
     /// let mut g : Sodg<16> = Sodg::empty(256);
     /// g.add(0);
@@ -212,7 +212,7 @@ impl<const N: usize> Sodg<N> {
     /// Just in case, if you need to put all names into a single line:
     ///
     /// ```
-    /// use std::str::FromStr;
+    /// use std::str::FromStr as _;
     /// use itertools::Itertools;
     /// use sodg::{Label, Sodg};
     /// let mut g : Sodg<16> = Sodg::empty(256);
@@ -244,7 +244,7 @@ impl<const N: usize> Sodg<N> {
     /// For example:
     ///
     /// ```
-    /// use std::str::FromStr;
+    /// use std::str::FromStr as _;
     /// use sodg::{Label, Sodg};
     /// let mut g : Sodg<16> = Sodg::empty(256);
     /// g.add(0);
@@ -271,7 +271,7 @@ impl<const N: usize> Sodg<N> {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::str::FromStr as _;
 
     use super::*;
 

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
 // SPDX-License-Identifier: MIT
 
+use crate::{BRANCH_NONE, BRANCH_STATIC, Persistence, Sodg};
 use crate::{Hex, Label};
-use crate::{Persistence, Sodg, BRANCH_NONE, BRANCH_STATIC};
 use anyhow::Context;
 #[cfg(debug_assertions)]
 use log::trace;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
 // SPDX-License-Identifier: MIT
 
-use crate::{BRANCH_NONE, BRANCH_STATIC, Persistence, Sodg};
-use crate::{Hex, Label};
-use anyhow::Context;
+use anyhow::Context as _;
 #[cfg(debug_assertions)]
 use log::trace;
+
+use crate::{BRANCH_NONE, BRANCH_STATIC, Persistence, Sodg};
+use crate::{Hex, Label};
 
 impl<const N: usize> Sodg<N> {
     /// Add a new vertex `v1` to itself.
@@ -269,158 +270,162 @@ impl<const N: usize> Sodg<N> {
 }
 
 #[cfg(test)]
-use std::str::FromStr;
+mod tests {
+    use std::str::FromStr;
 
-#[test]
-fn adds_simple_vertex() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(1);
-    g.add(2);
-    g.bind(1, 2, Label::Alpha(0));
-    assert_eq!(2, g.len());
-}
+    use super::*;
 
-#[test]
-fn sets_branch_correctly() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(1);
-    g.add(2);
-    g.bind(1, 2, Label::Alpha(0));
-    assert_eq!(1, g.branches.get(1).unwrap().len());
-    assert_eq!(2, g.branches.get(2).unwrap().len());
-    g.put(2, &Hex::from(42));
-    assert_eq!(&1, g.stores.get(2).unwrap());
-    g.add(3);
-    g.bind(1, 3, Label::Alpha(1));
-    assert_eq!(3, g.branches.get(2).unwrap().len());
-    g.add(4);
-    g.add(5);
-    g.bind(4, 5, Label::Alpha(0));
-    assert_eq!(2, g.branches.get(3).unwrap().len());
-    g.data(2);
-    assert_eq!(0, g.branches.get(2).unwrap().len());
-}
-
-#[test]
-fn fetches_kid() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(1);
-    g.add(2);
-    let k = Label::from_str("hello").unwrap();
-    g.bind(1, 2, k);
-    assert_eq!(2, g.kid(1, k).unwrap());
-}
-
-#[test]
-fn binds_two_names() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(1);
-    g.add(2);
-    let first = Label::from_str("first").unwrap();
-    g.bind(1, 2, first);
-    let second = Label::from_str("second").unwrap();
-    g.bind(1, 2, second);
-    assert_eq!(2, g.kid(1, first).unwrap());
-    assert_eq!(2, g.kid(1, second).unwrap());
-}
-
-#[test]
-fn overwrites_edge() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(1);
-    g.add(2);
-    g.bind(1, 2, Label::from_str("foo").unwrap());
-    g.add(3);
-    g.bind(1, 3, Label::from_str("foo").unwrap());
-    assert_eq!(3, g.kid(1, Label::from_str("foo").unwrap()).unwrap());
-}
-
-#[test]
-fn binds_to_root() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(0);
-    g.add(1);
-    g.bind(0, 1, Label::from_str("x").unwrap());
-    assert!(g.kid(0, Label::from_str("ρ").unwrap()).is_none());
-    assert!(g.kid(0, Label::from_str("σ").unwrap()).is_none());
-}
-
-#[test]
-fn sets_simple_data() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    let data = Hex::from_str_bytes("hello");
-    g.add(0);
-    g.put(0, &data);
-    assert_eq!(data, g.data(0).unwrap());
-}
-
-#[test]
-fn collects_garbage() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(1);
-    g.add(2);
-    g.bind(1, 2, Label::Alpha(0));
-    g.put(2, &Hex::from_str_bytes("hello"));
-    g.add(3);
-    g.bind(1, 3, Label::Alpha(0));
-    assert_eq!(3, g.len());
-    assert_eq!(3, g.branches.get(2).unwrap().len());
-    g.data(2);
-    assert_eq!(0, g.len());
-}
-
-#[test]
-fn finds_all_kids() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(0);
-    g.add(1);
-    g.bind(0, 1, Label::from_str("one").unwrap());
-    g.bind(0, 1, Label::from_str("two").unwrap());
-    assert_eq!(2, g.kids(0).count());
-    let mut names = vec![];
-    for (a, to) in g.kids(0) {
-        names.push(format!("{a}/{to}"));
+    #[test]
+    fn adds_simple_vertex() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(1);
+        g.add(2);
+        g.bind(1, 2, Label::Alpha(0));
+        assert_eq!(2, g.len());
     }
-    names.sort();
-    assert_eq!("one/1,two/1", names.join(","));
-}
 
-#[test]
-fn builds_list_of_kids() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(0);
-    g.add(1);
-    g.bind(0, 1, Label::from_str("one").unwrap());
-    g.bind(0, 1, Label::from_str("two").unwrap());
-    g.bind(0, 1, Label::from_str("three").unwrap());
-    let mut names: Vec<String> = g.kids(0).map(|(a, _)| format!("{a}")).collect();
-    names.sort();
-    assert_eq!("one,three,two", names.join(","));
-}
+    #[test]
+    fn sets_branch_correctly() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(1);
+        g.add(2);
+        g.bind(1, 2, Label::Alpha(0));
+        assert_eq!(1, g.branches.get(1).unwrap().len());
+        assert_eq!(2, g.branches.get(2).unwrap().len());
+        g.put(2, &Hex::from(42));
+        assert_eq!(&1, g.stores.get(2).unwrap());
+        g.add(3);
+        g.bind(1, 3, Label::Alpha(1));
+        assert_eq!(3, g.branches.get(2).unwrap().len());
+        g.add(4);
+        g.add(5);
+        g.bind(4, 5, Label::Alpha(0));
+        assert_eq!(2, g.branches.get(3).unwrap().len());
+        g.data(2);
+        assert_eq!(0, g.branches.get(2).unwrap().len());
+    }
 
-#[test]
-fn gets_data_from_empty_vertex() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(0);
-    assert!(g.data(0).is_none());
-}
+    #[test]
+    fn fetches_kid() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(1);
+        g.add(2);
+        let k = Label::from_str("hello").unwrap();
+        g.bind(1, 2, k);
+        assert_eq!(2, g.kid(1, k).unwrap());
+    }
 
-#[test]
-fn gets_absent_kid() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(0);
-    assert!(g.kid(0, Label::from_str("hello").unwrap()).is_none());
-}
+    #[test]
+    fn binds_two_names() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(1);
+        g.add(2);
+        let first = Label::from_str("first").unwrap();
+        g.bind(1, 2, first);
+        let second = Label::from_str("second").unwrap();
+        g.bind(1, 2, second);
+        assert_eq!(2, g.kid(1, first).unwrap());
+        assert_eq!(2, g.kid(1, second).unwrap());
+    }
 
-#[test]
-fn gets_kid_from_absent_vertex() {
-    let g: Sodg<16> = Sodg::empty(256);
-    assert!(g.kid(0, Label::from_str("hello").unwrap()).is_none());
-}
+    #[test]
+    fn overwrites_edge() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(1);
+        g.add(2);
+        g.bind(1, 2, Label::from_str("foo").unwrap());
+        g.add(3);
+        g.bind(1, 3, Label::from_str("foo").unwrap());
+        assert_eq!(3, g.kid(1, Label::from_str("foo").unwrap()).unwrap());
+    }
 
-#[test]
-fn adds_twice() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(0);
-    g.add(0);
+    #[test]
+    fn binds_to_root() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(1);
+        g.bind(0, 1, Label::from_str("x").unwrap());
+        assert!(g.kid(0, Label::from_str("ρ").unwrap()).is_none());
+        assert!(g.kid(0, Label::from_str("σ").unwrap()).is_none());
+    }
+
+    #[test]
+    fn sets_simple_data() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        let data = Hex::from_str_bytes("hello");
+        g.add(0);
+        g.put(0, &data);
+        assert_eq!(data, g.data(0).unwrap());
+    }
+
+    #[test]
+    fn collects_garbage() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(1);
+        g.add(2);
+        g.bind(1, 2, Label::Alpha(0));
+        g.put(2, &Hex::from_str_bytes("hello"));
+        g.add(3);
+        g.bind(1, 3, Label::Alpha(0));
+        assert_eq!(3, g.len());
+        assert_eq!(3, g.branches.get(2).unwrap().len());
+        g.data(2);
+        assert_eq!(0, g.len());
+    }
+
+    #[test]
+    fn finds_all_kids() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(1);
+        g.bind(0, 1, Label::from_str("one").unwrap());
+        g.bind(0, 1, Label::from_str("two").unwrap());
+        assert_eq!(2, g.kids(0).count());
+        let mut names = vec![];
+        for (a, to) in g.kids(0) {
+            names.push(format!("{a}/{to}"));
+        }
+        names.sort();
+        assert_eq!("one/1,two/1", names.join(","));
+    }
+
+    #[test]
+    fn builds_list_of_kids() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(1);
+        g.bind(0, 1, Label::from_str("one").unwrap());
+        g.bind(0, 1, Label::from_str("two").unwrap());
+        g.bind(0, 1, Label::from_str("three").unwrap());
+        let mut names: Vec<String> = g.kids(0).map(|(a, _)| format!("{a}")).collect();
+        names.sort();
+        assert_eq!("one,three,two", names.join(","));
+    }
+
+    #[test]
+    fn gets_data_from_empty_vertex() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        assert!(g.data(0).is_none());
+    }
+
+    #[test]
+    fn gets_absent_kid() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        assert!(g.kid(0, Label::from_str("hello").unwrap()).is_none());
+    }
+
+    #[test]
+    fn gets_kid_from_absent_vertex() {
+        let g: Sodg<16> = Sodg::empty(256);
+        assert!(g.kid(0, Label::from_str("hello").unwrap()).is_none());
+    }
+
+    #[test]
+    fn adds_twice() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(0);
+    }
 }

--- a/src/script.rs
+++ b/src/script.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use std::collections::HashMap;
-use std::str::FromStr;
+use std::str::FromStr as _;
 use std::sync::LazyLock as Lazy;
 
 use anyhow::{Context as _, Result, bail};
@@ -26,9 +26,10 @@ impl Script {
     /// For example:
     ///
     /// ```
-    /// use std::str::FromStr;
+    /// use std::str::FromStr as _;
     /// use sodg::{Label, Script};
     /// use sodg::Sodg;
+    ///
     /// let mut s = Script::from_str(
     ///   "ADD(0); ADD($ν1); BIND(ν0, $ν1, foo);"
     /// );

--- a/src/script.rs
+++ b/src/script.rs
@@ -1,14 +1,16 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
 // SPDX-License-Identifier: MIT
 
-use crate::{Hex, Script};
-use crate::{Label, Sodg};
-use anyhow::{Context, Result, anyhow};
-use log::trace;
-use regex::Regex;
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::LazyLock as Lazy;
+
+use anyhow::{Context as _, Result, bail};
+use log::trace;
+use regex::Regex;
+
+use crate::{Hex, Script};
+use crate::{Label, Sodg};
 
 impl Script {
     /// Make a new one, parsing a string with instructions.
@@ -90,23 +92,22 @@ impl Script {
             .collect();
         match &cap[1] {
             "ADD" => {
-                let v = self.parse(args.first().with_context(|| "V is expected")?, g)?;
+                let v = self.parse(args.first().context("V is expected")?, g)?;
                 g.add(v);
             }
             "BIND" => {
-                let v1 = self.parse(args.first().with_context(|| "V1 is expected")?, g)?;
-                let v2 = self.parse(args.get(1).with_context(|| "V2 is expected")?, g)?;
-                let a =
-                    Label::from_str(args.get(2).with_context(|| "Label is expected")?.as_str())?;
+                let v1 = self.parse(args.first().context("V1 is expected")?, g)?;
+                let v2 = self.parse(args.get(1).context("V2 is expected")?, g)?;
+                let a = Label::from_str(args.get(2).context("Label is expected")?.as_str())?;
                 g.bind(v1, v2, a);
             }
             "PUT" => {
-                let v = self.parse(args.first().with_context(|| "V is expected")?, g)?;
-                let d = Self::parse_data(args.get(1).with_context(|| "Data is expected")?)?;
+                let v = self.parse(args.first().context("V is expected")?, g)?;
+                let d = Self::parse_data(args.get(1).context("Data is expected")?)?;
                 g.put(v, &d);
             }
             cmd => {
-                return Err(anyhow!("Unknown command: {cmd}"));
+                bail!("Unknown command: {cmd}");
             }
         }
         Ok(())
@@ -122,15 +123,14 @@ impl Script {
         static DATA: Lazy<Regex> =
             Lazy::new(|| Regex::new("^[0-9A-Fa-f]{2}([0-9A-Fa-f]{2})*$").unwrap());
         let d: &str = &DATA_STRIP.replace_all(s, "");
-        if DATA.is_match(d) {
-            let bytes: Vec<u8> = (0..d.len())
-                .step_by(2)
-                .map(|i| u8::from_str_radix(&d[i..i + 2], 16).unwrap())
-                .collect();
-            Ok(Hex::from_vec(bytes))
-        } else {
-            Err(anyhow!("Can't parse data '{s}'"))
+        if !DATA.is_match(d) {
+            bail!("Can't parse data '{s}'");
         }
+        let bytes: Vec<u8> = (0..d.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&d[i..i + 2], 16).unwrap())
+            .collect();
+        Ok(Hex::from_vec(bytes))
     }
 
     /// Parse `$ν5` into `5`, and `ν23` into `23`, and `42` into `42`.
@@ -139,10 +139,7 @@ impl Script {
     ///
     /// If impossible to parse, an error will be returned.
     fn parse<const N: usize>(&mut self, s: &str, g: &mut Sodg<N>) -> Result<usize> {
-        let head = s
-            .chars()
-            .next()
-            .with_context(|| "Empty identifier".to_string())?;
+        let head = s.chars().next().context("Empty identifier")?;
         if head == '$' || head == 'ν' {
             let tail: String = s.chars().skip(1).collect::<Vec<_>>().into_iter().collect();
             if head == '$' {
@@ -159,20 +156,22 @@ impl Script {
 }
 
 #[cfg(test)]
-use std::str;
+mod tests {
+    use super::*;
 
-#[test]
-fn simple_command() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    let mut s = Script::from_str(
-        "
-        ADD(0);  ADD($ν1); # adding two vertices
-        BIND(ν0, $ν1, foo  );
-        PUT($ν1  , d0-bf-D1-80-d0-B8-d0-b2-d0-b5-d1-82);
-        ",
-    );
-    let total = s.deploy_to(&mut g).unwrap();
-    assert_eq!(4, total);
-    assert_eq!("привет", g.data(1).unwrap().to_utf8().unwrap());
-    assert_eq!(1, g.kid(0, Label::from_str("foo").unwrap()).unwrap());
+    #[test]
+    fn simple_command() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        let mut s = Script::from_str(
+            "
+            ADD(0);  ADD($ν1); # adding two vertices
+            BIND(ν0, $ν1, foo  );
+            PUT($ν1  , d0-bf-D1-80-d0-B8-d0-b2-d0-b5-d1-82);
+            ",
+        );
+        let total = s.deploy_to(&mut g).unwrap();
+        assert_eq!(4, total);
+        assert_eq!("привет", g.data(1).unwrap().to_utf8().unwrap());
+        assert_eq!(1, g.kid(0, Label::from_str("foo").unwrap()).unwrap());
+    }
 }

--- a/src/script.rs
+++ b/src/script.rs
@@ -3,7 +3,7 @@
 
 use crate::{Hex, Script};
 use crate::{Label, Sodg};
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use log::trace;
 use regex::Regex;
 use std::collections::HashMap;

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -63,7 +63,7 @@ impl<const N: usize> Sodg<N> {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::str::FromStr as _;
 
     use tempfile::TempDir;
 

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
 // SPDX-License-Identifier: MIT
 
-use crate::{Label, Sodg};
 use anyhow::Result;
 use log::trace;
 use std::collections::HashSet;
+
+use crate::{Label, Sodg};
 
 impl<const N: usize> Sodg<N> {
     /// Take a slice of the graph, keeping only the vertex specified
@@ -19,7 +20,7 @@ impl<const N: usize> Sodg<N> {
         trace!(
             "#slice: taken {} vertices out of {} at ν{v}",
             g.len(),
-            self.len()
+            self.len(),
         );
         Ok(g)
     }
@@ -74,50 +75,54 @@ impl<const N: usize> Sodg<N> {
         trace!(
             "#slice_some: taken {} vertices out of {} at ν{v}",
             ng.len(),
-            self.len()
+            self.len(),
         );
         Ok(ng)
     }
 }
 
 #[cfg(test)]
-use std::str::FromStr;
+mod tests {
+    use std::str::FromStr;
 
-#[test]
-fn makes_a_slice() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(0);
-    g.add(1);
-    g.bind(0, 1, Label::from_str("foo").unwrap());
-    g.add(2);
-    g.bind(0, 2, Label::from_str("bar").unwrap());
-    assert_eq!(1, g.slice(1).unwrap().len());
-    assert_eq!(1, g.slice(2).unwrap().len());
-}
+    use super::*;
 
-#[test]
-fn makes_a_partial_slice() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(0);
-    g.add(1);
-    g.bind(0, 1, Label::from_str("foo").unwrap());
-    g.add(2);
-    g.bind(1, 2, Label::from_str("bar").unwrap());
-    let slice = g.slice_some(1, |_v, _to, _a| false).unwrap();
-    assert_eq!(1, slice.len());
-}
+    #[test]
+    fn makes_a_slice() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(1);
+        g.bind(0, 1, Label::from_str("foo").unwrap());
+        g.add(2);
+        g.bind(0, 2, Label::from_str("bar").unwrap());
+        assert_eq!(1, g.slice(1).unwrap().len());
+        assert_eq!(1, g.slice(2).unwrap().len());
+    }
 
-#[test]
-fn skips_some_vertices() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(0);
-    g.add(1);
-    g.bind(0, 1, Label::from_str("foo").unwrap());
-    g.add(2);
-    g.bind(0, 2, Label::from_str("+bar").unwrap());
-    let slice = g
-        .slice_some(0, |_, _, a| !a.to_string().starts_with('+'))
-        .unwrap();
-    assert_eq!(2, slice.len());
-    assert_eq!(1, slice.kids(0).count());
+    #[test]
+    fn makes_a_partial_slice() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(1);
+        g.bind(0, 1, Label::from_str("foo").unwrap());
+        g.add(2);
+        g.bind(1, 2, Label::from_str("bar").unwrap());
+        let slice = g.slice_some(1, |_v, _to, _a| false).unwrap();
+        assert_eq!(1, slice.len());
+    }
+
+    #[test]
+    fn skips_some_vertices() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.add(1);
+        g.bind(0, 1, Label::from_str("foo").unwrap());
+        g.add(2);
+        g.bind(0, 2, Label::from_str("+bar").unwrap());
+        let slice = g
+            .slice_some(0, |_, _, a| !a.to_string().starts_with('+'))
+            .unwrap();
+        assert_eq!(2, slice.len());
+        assert_eq!(1, slice.kids(0).count());
+    }
 }

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
 // SPDX-License-Identifier: MIT
 
+use std::collections::HashSet;
+
 use anyhow::Result;
 use log::trace;
-use std::collections::HashSet;
 
 use crate::{Label, Sodg};
 
@@ -83,7 +84,7 @@ impl<const N: usize> Sodg<N> {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::str::FromStr as _;
 
     use super::*;
 

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
 // SPDX-License-Identifier: MIT
 
-use crate::{Persistence, Sodg};
 use anyhow::Result;
-use itertools::Itertools;
+use itertools::Itertools as _;
 use xml_builder::{XMLBuilder, XMLElement, XMLVersion};
+
+use crate::{Persistence, Sodg};
 
 impl<const N: usize> Sodg<N> {
     /// Make XML graph.
@@ -77,37 +78,35 @@ impl<const N: usize> Sodg<N> {
 }
 
 #[cfg(test)]
-use sxd_xpath::evaluate_xpath;
+mod tests {
+    use std::str::FromStr;
 
-#[cfg(test)]
-use crate::Hex;
+    use sxd_xpath::evaluate_xpath;
 
-#[cfg(test)]
-use crate::Label;
+    use super::*;
+    use crate::{Hex, Label};
 
-#[cfg(test)]
-use std::str::FromStr;
-
-#[test]
-fn prints_simple_graph() {
-    let mut g: Sodg<16> = Sodg::empty(256);
-    g.add(0);
-    g.put(0, &Hex::from_str_bytes("hello"));
-    g.add(1);
-    g.bind(0, 1, Label::from_str("foo").unwrap());
-    let xml = g.to_xml().unwrap();
-    let parser = sxd_document::parser::parse(xml.as_str()).unwrap();
-    let doc = parser.as_document();
-    assert_eq!(
-        "foo",
-        evaluate_xpath(&doc, "/sodg/v[@id=0]/e[1]/@a")
-            .unwrap()
-            .string()
-    );
-    assert_eq!(
-        "68 65 6C 6C 6F",
-        evaluate_xpath(&doc, "/sodg/v[@id=0]/data")
-            .unwrap()
-            .string()
-    );
+    #[test]
+    fn prints_simple_graph() {
+        let mut g: Sodg<16> = Sodg::empty(256);
+        g.add(0);
+        g.put(0, &Hex::from_str_bytes("hello"));
+        g.add(1);
+        g.bind(0, 1, Label::from_str("foo").unwrap());
+        let xml = g.to_xml().unwrap();
+        let parser = sxd_document::parser::parse(xml.as_str()).unwrap();
+        let doc = parser.as_document();
+        assert_eq!(
+            "foo",
+            evaluate_xpath(&doc, "/sodg/v[@id=0]/e[1]/@a")
+                .unwrap()
+                .string(),
+        );
+        assert_eq!(
+            "68 65 6C 6C 6F",
+            evaluate_xpath(&doc, "/sodg/v[@id=0]/data")
+                .unwrap()
+                .string(),
+        );
+    }
 }

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -13,7 +13,7 @@ impl<const N: usize> Sodg<N> {
     /// For example, for this code:
     ///
     /// ```
-    /// use std::str::FromStr;
+    /// use std::str::FromStr as _;
     /// use sodg::{Hex, Label};
     /// use sodg::Sodg;
     /// let mut g : Sodg<16> = Sodg::empty(256);
@@ -79,7 +79,7 @@ impl<const N: usize> Sodg<N> {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::str::FromStr as _;
 
     use sxd_xpath::evaluate_xpath;
 


### PR DESCRIPTION
Asqar Arslanov, B23-SD-01
a.arslanov@innopolis.university

This PR contains minor changes that make the codebase more idiomatic and up-to-date.

Closes #206, closes #207, closes #208.

Additional changes:

- Sort `use` statements in the following order:

  ```rust
  use std::xxx;
  use std::yyy;

  use external_xxx;
  use external_yyy;

  use crate::xxx;
  use super::yyy;
  ```

- Put `mod` declarations after `use` statements.

- Use `anyhow::bail!(...)` instead of `return Err(anyhow::anyhow!(...))`.

- Import traits unnameably (e.g., `anyhow::Context as _`).

- Replace `anyhow`’s `.with_context(|| ...)` with `.context(...)` in appropriate places.

- Add trailing commas to macro calls (`rustfmt` can’t do it by itself).