### PR TITLE
#256 drop dead `gc` feature from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,6 @@ homepage = "https://github.com/objectionary/sodg"
 keywords = ["graph", "oop"]
 categories = ["data-structures", "memory-management"]
 
-[features]
-gc = []
-
 [dependencies]
 anyhow = "1.0.100"
 bincode = { version = "2.0.1", features = ["serde"] }


### PR DESCRIPTION
The \`[features] gc = []\` entry in \`Cargo.toml\` has no \`#[cfg(feature = "gc")]\` consumer anywhere in \`src/\` or \`benches/\`. A grep for \`cfg(feature\` returns zero hits, so enabling the flag compiles to nothing while the CI \`--all-features\` matrix at \`.github/workflows/cargo.yml:23-26\` silently widens around it.

This PR removes lines 16-18 of \`Cargo.toml\` (the entire \`[features]\` block, since \`gc\` was the only entry). Downstream crates that opt into \`gc\` no longer get a no-op feature, and the CI \`--all-features\` flag now matches the actual feature surface.

Ran locally: \`cargo check --all-features\`, \`cargo fmt --check\`, \`cargo clippy --all-targets --all-features\`, \`cargo test --all-features\` (43 unit tests + doctests pass), and \`cargo doc --no-deps\` — all green.

Closes #256